### PR TITLE
[chrome.ndk] revert change to keep align with ndk 22/23

### DIFF
--- a/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/android/looper.h
+++ b/toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/android/looper.h
@@ -205,7 +205,7 @@ int ALooper_pollOnce(int timeoutMillis, int* outFd, int* outEvents, void** outDa
  * Removed in API 34 as ALooper_pollAll can swallow ALooper_wake calls.
  * Use ALooper_pollOnce instead.
  */
-int ALooper_pollAll(int timeoutMillis, int* outFd, int* outEvents, void** outData) __REMOVED_IN(1);
+int ALooper_pollAll(int timeoutMillis, int* outFd, int* outEvents, void** outData);
 
 /**
  * Wakes the poll asynchronously.


### PR DESCRIPTION
We are using latest ndk header files from google upstream, which is different against the ndk matching chrome 109.
For ./toolchains/llvm/prebuilt/linux-x86_64/sysroot/usr/include/android/looper.h, new version marked ALooper_pollAll with "__REMOVED_IN(1)", while in ndk for chrome 109, there is no such flag.

Diff and see only this change happened for looper.h.

Current solution: revert and removed the "__REMOVED_IN(1)".

FIXME: The final solution may be a new ndk, with:
- proper files match ndk 22/23 that chrome 109 depends on
- proper kernel uapi header files of 5.10 that aosp12/riscv64 for T-HEAD dev board.